### PR TITLE
Naive ForEach compiler implementation using Unnest operator.

### DIFF
--- a/tfx/dsl/compiler/compiler_test.py
+++ b/tfx/dsl/compiler/compiler_test.py
@@ -21,6 +21,7 @@ from tfx.dsl.compiler import compiler
 from tfx.dsl.compiler.testdata import additional_properties_test_pipeline_async
 from tfx.dsl.compiler.testdata import channel_union_pipeline
 from tfx.dsl.compiler.testdata import conditional_pipeline
+from tfx.dsl.compiler.testdata import foreach_pipeline
 from tfx.dsl.compiler.testdata import iris_pipeline_async
 from tfx.dsl.compiler.testdata import iris_pipeline_sync
 from tfx.dsl.compiler.testdata import pipeline_root_placeholder
@@ -71,10 +72,12 @@ class CompilerTest(tf.test.TestCase, parameterized.TestCase):
       ("_async_pipeline", iris_pipeline_async, "iris_pipeline_async_ir.pbtxt"),
       ("_conditional_pipeline", conditional_pipeline,
        "conditional_pipeline_ir.pbtxt"),
+      ("_foreach", foreach_pipeline, "foreach_pipeline_ir.pbtxt"),
       ("_channel_union_pipeline", channel_union_pipeline,
        "channel_union_pipeline_ir.pbtxt"),
       ("_pipeline_root_placeholder", pipeline_root_placeholder,
-       "pipeline_root_placeholder_ir.pbtxt"))
+       "pipeline_root_placeholder_ir.pbtxt"),
+  )
   def testCompile(self, pipeline_module, expected_result_path):
     """Tests compiling the whole pipeline."""
     dsl_compiler = compiler.Compiler()

--- a/tfx/dsl/compiler/testdata/foreach_pipeline.py
+++ b/tfx/dsl/compiler/testdata/foreach_pipeline.py
@@ -1,0 +1,73 @@
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sample pipeline with ForEach context."""
+
+from tfx.components import CsvExampleGen
+from tfx.components import Pusher
+from tfx.components import SchemaGen
+from tfx.components import StatisticsGen
+from tfx.components import Trainer
+from tfx.dsl.components.common import resolver
+from tfx.dsl.control_flow import for_each
+from tfx.dsl.input_resolution.strategies import latest_artifact_strategy
+from tfx.orchestration import pipeline
+from tfx.proto import pusher_pb2
+from tfx.proto import trainer_pb2
+
+
+def create_test_pipeline():
+  """Creates a sample pipeline with ForEach context."""
+
+  example_gen = CsvExampleGen(input_base='/data/mydummy_dataset')
+
+  with for_each.ForEach(example_gen.outputs['examples']) as each_example:
+    statistics_gen = StatisticsGen(examples=each_example)
+
+  latest_stats_resolver = resolver.Resolver(
+      statistics=statistics_gen.outputs['statistics'],
+      strategy_class=latest_artifact_strategy.LatestArtifactStrategy,
+  ).with_id('latest_stats_resolver')
+
+  schema_gen = SchemaGen(statistics=latest_stats_resolver.outputs['statistics'])
+
+  with for_each.ForEach(example_gen.outputs['examples']) as each_example:
+    trainer = Trainer(
+        module_file='/src/train.py',
+        examples=each_example,
+        schema=schema_gen.outputs['schema'],
+        train_args=trainer_pb2.TrainArgs(num_steps=2000),
+    )
+
+  with for_each.ForEach(trainer.outputs['model']) as each_model:
+    pusher = Pusher(
+        model=each_model,
+        push_destination=pusher_pb2.PushDestination(
+            filesystem=pusher_pb2.PushDestination.Filesystem(
+                base_directory='/models')),
+    )
+
+  return pipeline.Pipeline(
+      pipeline_name='foreach',
+      pipeline_root='/tfx/pipelines/foreach',
+      components=[
+          example_gen,
+          statistics_gen,
+          latest_stats_resolver,
+          schema_gen,
+          trainer,
+          pusher,
+      ],
+      enable_cache=True,
+      execution_mode=pipeline.ExecutionMode.SYNC,
+  )

--- a/tfx/dsl/compiler/testdata/foreach_pipeline_ir.pbtxt
+++ b/tfx/dsl/compiler/testdata/foreach_pipeline_ir.pbtxt
@@ -1,0 +1,929 @@
+# proto-file: tfx/proto/orchestration/pipeline.proto
+# proto-message: Pipeline
+pipeline_info {
+  id: "foreach"
+}
+nodes {
+  pipeline_node {
+    node_info {
+      type {
+        name: "tfx.components.example_gen.csv_example_gen.component.CsvExampleGen"
+      }
+      id: "CsvExampleGen"
+    }
+    contexts {
+      contexts {
+        type {
+          name: "pipeline"
+        }
+        name {
+          field_value {
+            string_value: "foreach"
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "pipeline_run"
+        }
+        name {
+          runtime_parameter {
+            name: "pipeline-run-id"
+            type: STRING
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "node"
+        }
+        name {
+          field_value {
+            string_value: "foreach.CsvExampleGen"
+          }
+        }
+      }
+    }
+    outputs {
+      outputs {
+        key: "examples"
+        value {
+          artifact_spec {
+            type {
+              name: "Examples"
+              properties {
+                key: "span"
+                value: INT
+              }
+              properties {
+                key: "split_names"
+                value: STRING
+              }
+              properties {
+                key: "version"
+                value: INT
+              }
+              base_type: DATASET
+            }
+          }
+        }
+      }
+    }
+    parameters {
+      parameters {
+        key: "input_base"
+        value {
+          field_value {
+            string_value: "/data/mydummy_dataset"
+          }
+        }
+      }
+      parameters {
+        key: "input_config"
+        value {
+          field_value {
+            string_value: "{\n  \"splits\": [\n    {\n      \"name\": \"single_split\",\n      \"pattern\": \"*\"\n    }\n  ]\n}"
+          }
+        }
+      }
+      parameters {
+        key: "output_config"
+        value {
+          field_value {
+            string_value: "{\n  \"split_config\": {\n    \"splits\": [\n      {\n        \"hash_buckets\": 2,\n        \"name\": \"train\"\n      },\n      {\n        \"hash_buckets\": 1,\n        \"name\": \"eval\"\n      }\n    ]\n  }\n}"
+          }
+        }
+      }
+      parameters {
+        key: "output_data_format"
+        value {
+          field_value {
+            int_value: 6
+          }
+        }
+      }
+      parameters {
+        key: "output_file_format"
+        value {
+          field_value {
+            int_value: 5
+          }
+        }
+      }
+    }
+    downstream_nodes: "StatisticsGen"
+    downstream_nodes: "Trainer"
+    execution_options {
+      caching_options {
+        enable_cache: true
+      }
+    }
+  }
+}
+nodes {
+  pipeline_node {
+    node_info {
+      type {
+        name: "tfx.components.statistics_gen.component.StatisticsGen"
+      }
+      id: "StatisticsGen"
+    }
+    contexts {
+      contexts {
+        type {
+          name: "pipeline"
+        }
+        name {
+          field_value {
+            string_value: "foreach"
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "pipeline_run"
+        }
+        name {
+          runtime_parameter {
+            name: "pipeline-run-id"
+            type: STRING
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "node"
+        }
+        name {
+          field_value {
+            string_value: "foreach.StatisticsGen"
+          }
+        }
+      }
+    }
+    inputs {
+      inputs {
+        key: "examples"
+        value {
+          channels {
+            producer_node_query {
+              id: "CsvExampleGen"
+            }
+            context_queries {
+              type {
+                name: "pipeline"
+              }
+              name {
+                field_value {
+                  string_value: "foreach"
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "pipeline_run"
+              }
+              name {
+                runtime_parameter {
+                  name: "pipeline-run-id"
+                  type: STRING
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "node"
+              }
+              name {
+                field_value {
+                  string_value: "foreach.CsvExampleGen"
+                }
+              }
+            }
+            artifact_query {
+              type {
+                name: "Examples"
+                base_type: DATASET
+              }
+            }
+            output_key: "examples"
+          }
+          min_count: 1
+        }
+      }
+      resolver_config {
+        resolver_steps {
+          class_path: "tfx.dsl.input_resolution.ops.unnest_op.Unnest"
+          config_json: "{\"key\": \"examples\"}"
+        }
+        resolver_steps {
+          class_path: "tfx.dsl.input_resolution.ops.skip_if_empty_op.SkipIfEmpty"
+          config_json: "{}"
+        }
+      }
+    }
+    outputs {
+      outputs {
+        key: "statistics"
+        value {
+          artifact_spec {
+            type {
+              name: "ExampleStatistics"
+              properties {
+                key: "span"
+                value: INT
+              }
+              properties {
+                key: "split_names"
+                value: STRING
+              }
+              base_type: STATISTICS
+            }
+          }
+        }
+      }
+    }
+    parameters {
+      parameters {
+        key: "exclude_splits"
+        value {
+          field_value {
+            string_value: "[]"
+          }
+        }
+      }
+    }
+    upstream_nodes: "CsvExampleGen"
+    downstream_nodes: "latest_stats_resolver"
+    execution_options {
+      caching_options {
+        enable_cache: true
+      }
+    }
+  }
+}
+nodes {
+  pipeline_node {
+    node_info {
+      type {
+        name: "tfx.dsl.components.common.resolver.Resolver"
+      }
+      id: "latest_stats_resolver"
+    }
+    contexts {
+      contexts {
+        type {
+          name: "pipeline"
+        }
+        name {
+          field_value {
+            string_value: "foreach"
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "pipeline_run"
+        }
+        name {
+          runtime_parameter {
+            name: "pipeline-run-id"
+            type: STRING
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "node"
+        }
+        name {
+          field_value {
+            string_value: "foreach.latest_stats_resolver"
+          }
+        }
+      }
+    }
+    inputs {
+      inputs {
+        key: "statistics"
+        value {
+          channels {
+            producer_node_query {
+              id: "StatisticsGen"
+            }
+            context_queries {
+              type {
+                name: "pipeline"
+              }
+              name {
+                field_value {
+                  string_value: "foreach"
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "pipeline_run"
+              }
+              name {
+                runtime_parameter {
+                  name: "pipeline-run-id"
+                  type: STRING
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "node"
+              }
+              name {
+                field_value {
+                  string_value: "foreach.StatisticsGen"
+                }
+              }
+            }
+            artifact_query {
+              type {
+                name: "ExampleStatistics"
+                base_type: STATISTICS
+              }
+            }
+            output_key: "statistics"
+          }
+        }
+      }
+      resolver_config {
+        resolver_steps {
+          class_path: "tfx.dsl.input_resolution.strategies.latest_artifact_strategy.LatestArtifactStrategy"
+          config_json: "{}"
+          input_keys: "statistics"
+        }
+      }
+    }
+    upstream_nodes: "StatisticsGen"
+    downstream_nodes: "SchemaGen"
+    execution_options {
+      caching_options {
+        enable_cache: true
+      }
+    }
+  }
+}
+nodes {
+  pipeline_node {
+    node_info {
+      type {
+        name: "tfx.components.schema_gen.component.SchemaGen"
+      }
+      id: "SchemaGen"
+    }
+    contexts {
+      contexts {
+        type {
+          name: "pipeline"
+        }
+        name {
+          field_value {
+            string_value: "foreach"
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "pipeline_run"
+        }
+        name {
+          runtime_parameter {
+            name: "pipeline-run-id"
+            type: STRING
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "node"
+        }
+        name {
+          field_value {
+            string_value: "foreach.SchemaGen"
+          }
+        }
+      }
+    }
+    inputs {
+      inputs {
+        key: "statistics"
+        value {
+          channels {
+            producer_node_query {
+              id: "latest_stats_resolver"
+            }
+            context_queries {
+              type {
+                name: "pipeline"
+              }
+              name {
+                field_value {
+                  string_value: "foreach"
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "pipeline_run"
+              }
+              name {
+                runtime_parameter {
+                  name: "pipeline-run-id"
+                  type: STRING
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "node"
+              }
+              name {
+                field_value {
+                  string_value: "foreach.latest_stats_resolver"
+                }
+              }
+            }
+            artifact_query {
+              type {
+                name: "ExampleStatistics"
+                base_type: STATISTICS
+              }
+            }
+            output_key: "statistics"
+          }
+          min_count: 1
+        }
+      }
+    }
+    outputs {
+      outputs {
+        key: "schema"
+        value {
+          artifact_spec {
+            type {
+              name: "Schema"
+            }
+          }
+        }
+      }
+    }
+    parameters {
+      parameters {
+        key: "exclude_splits"
+        value {
+          field_value {
+            string_value: "[]"
+          }
+        }
+      }
+      parameters {
+        key: "infer_feature_shape"
+        value {
+          field_value {
+            int_value: 1
+          }
+        }
+      }
+    }
+    upstream_nodes: "latest_stats_resolver"
+    downstream_nodes: "Trainer"
+    execution_options {
+      caching_options {
+        enable_cache: true
+      }
+    }
+  }
+}
+nodes {
+  pipeline_node {
+    node_info {
+      type {
+        name: "tfx.components.trainer.component.Trainer"
+      }
+      id: "Trainer"
+    }
+    contexts {
+      contexts {
+        type {
+          name: "pipeline"
+        }
+        name {
+          field_value {
+            string_value: "foreach"
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "pipeline_run"
+        }
+        name {
+          runtime_parameter {
+            name: "pipeline-run-id"
+            type: STRING
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "node"
+        }
+        name {
+          field_value {
+            string_value: "foreach.Trainer"
+          }
+        }
+      }
+    }
+    inputs {
+      inputs {
+        key: "examples"
+        value {
+          channels {
+            producer_node_query {
+              id: "CsvExampleGen"
+            }
+            context_queries {
+              type {
+                name: "pipeline"
+              }
+              name {
+                field_value {
+                  string_value: "foreach"
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "pipeline_run"
+              }
+              name {
+                runtime_parameter {
+                  name: "pipeline-run-id"
+                  type: STRING
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "node"
+              }
+              name {
+                field_value {
+                  string_value: "foreach.CsvExampleGen"
+                }
+              }
+            }
+            artifact_query {
+              type {
+                name: "Examples"
+                base_type: DATASET
+              }
+            }
+            output_key: "examples"
+          }
+          min_count: 1
+        }
+      }
+      inputs {
+        key: "schema"
+        value {
+          channels {
+            producer_node_query {
+              id: "SchemaGen"
+            }
+            context_queries {
+              type {
+                name: "pipeline"
+              }
+              name {
+                field_value {
+                  string_value: "foreach"
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "pipeline_run"
+              }
+              name {
+                runtime_parameter {
+                  name: "pipeline-run-id"
+                  type: STRING
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "node"
+              }
+              name {
+                field_value {
+                  string_value: "foreach.SchemaGen"
+                }
+              }
+            }
+            artifact_query {
+              type {
+                name: "Schema"
+              }
+            }
+            output_key: "schema"
+          }
+        }
+      }
+      resolver_config {
+        resolver_steps {
+          class_path: "tfx.dsl.input_resolution.ops.unnest_op.Unnest"
+          config_json: "{\"key\": \"examples\"}"
+        }
+        resolver_steps {
+          class_path: "tfx.dsl.input_resolution.ops.skip_if_empty_op.SkipIfEmpty"
+          config_json: "{}"
+        }
+      }
+    }
+    outputs {
+      outputs {
+        key: "model"
+        value {
+          artifact_spec {
+            type {
+              name: "Model"
+            }
+          }
+        }
+      }
+      outputs {
+        key: "model_run"
+        value {
+          artifact_spec {
+            type {
+              name: "ModelRun"
+            }
+          }
+        }
+      }
+    }
+    parameters {
+      parameters {
+        key: "custom_config"
+        value {
+          field_value {
+            string_value: "null"
+          }
+        }
+      }
+      parameters {
+        key: "eval_args"
+        value {
+          field_value {
+            string_value: "{}"
+          }
+        }
+      }
+      parameters {
+        key: "module_file"
+        value {
+          field_value {
+            string_value: "/src/train.py"
+          }
+        }
+      }
+      parameters {
+        key: "train_args"
+        value {
+          field_value {
+            string_value: "{\n  \"num_steps\": 2000\n}"
+          }
+        }
+      }
+    }
+    upstream_nodes: "CsvExampleGen"
+    upstream_nodes: "SchemaGen"
+    downstream_nodes: "Pusher"
+    execution_options {
+      caching_options {
+        enable_cache: true
+      }
+    }
+  }
+}
+nodes {
+  pipeline_node {
+    node_info {
+      type {
+        name: "tfx.components.pusher.component.Pusher"
+      }
+      id: "Pusher"
+    }
+    contexts {
+      contexts {
+        type {
+          name: "pipeline"
+        }
+        name {
+          field_value {
+            string_value: "foreach"
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "pipeline_run"
+        }
+        name {
+          runtime_parameter {
+            name: "pipeline-run-id"
+            type: STRING
+          }
+        }
+      }
+      contexts {
+        type {
+          name: "node"
+        }
+        name {
+          field_value {
+            string_value: "foreach.Pusher"
+          }
+        }
+      }
+    }
+    inputs {
+      inputs {
+        key: "model"
+        value {
+          channels {
+            producer_node_query {
+              id: "Trainer"
+            }
+            context_queries {
+              type {
+                name: "pipeline"
+              }
+              name {
+                field_value {
+                  string_value: "foreach"
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "pipeline_run"
+              }
+              name {
+                runtime_parameter {
+                  name: "pipeline-run-id"
+                  type: STRING
+                }
+              }
+            }
+            context_queries {
+              type {
+                name: "node"
+              }
+              name {
+                field_value {
+                  string_value: "foreach.Trainer"
+                }
+              }
+            }
+            artifact_query {
+              type {
+                name: "Model"
+              }
+            }
+            output_key: "model"
+          }
+        }
+      }
+      resolver_config {
+        resolver_steps {
+          class_path: "tfx.dsl.input_resolution.ops.unnest_op.Unnest"
+          config_json: "{\"key\": \"model\"}"
+        }
+        resolver_steps {
+          class_path: "tfx.dsl.input_resolution.ops.skip_if_empty_op.SkipIfEmpty"
+          config_json: "{}"
+        }
+      }
+    }
+    outputs {
+      outputs {
+        key: "pushed_model"
+        value {
+          artifact_spec {
+            type {
+              name: "PushedModel"
+            }
+          }
+        }
+      }
+    }
+    parameters {
+      parameters {
+        key: "custom_config"
+        value {
+          field_value {
+            string_value: "null"
+          }
+        }
+      }
+      parameters {
+        key: "push_destination"
+        value {
+          field_value {
+            string_value: "{\n  \"filesystem\": {\n    \"base_directory\": \"/models\"\n  }\n}"
+          }
+        }
+      }
+    }
+    upstream_nodes: "Trainer"
+    execution_options {
+      caching_options {
+        enable_cache: true
+      }
+    }
+  }
+}
+runtime_spec {
+  pipeline_root {
+    runtime_parameter {
+      name: "pipeline-root"
+      type: STRING
+      default_value {
+        string_value: "/tfx/pipelines/foreach"
+      }
+    }
+  }
+  pipeline_run_id {
+    runtime_parameter {
+      name: "pipeline-run-id"
+      type: STRING
+    }
+  }
+}
+execution_mode: SYNC
+deployment_config {
+  [type.googleapis.com/tfx.orchestration.IntermediateDeploymentConfig] {
+    executor_specs {
+      key: "CsvExampleGen"
+      value {
+        [type.googleapis.com/tfx.orchestration.executable_spec.BeamExecutableSpec] {
+          python_executor_spec {
+            class_path: "tfx.components.example_gen.csv_example_gen.executor.Executor"
+          }
+        }
+      }
+    }
+    executor_specs {
+      key: "Pusher"
+      value {
+        [type.googleapis.com/tfx.orchestration.executable_spec.PythonClassExecutableSpec] {
+          class_path: "tfx.components.pusher.executor.Executor"
+        }
+      }
+    }
+    executor_specs {
+      key: "SchemaGen"
+      value {
+        [type.googleapis.com/tfx.orchestration.executable_spec.PythonClassExecutableSpec] {
+          class_path: "tfx.components.schema_gen.executor.Executor"
+        }
+      }
+    }
+    executor_specs {
+      key: "StatisticsGen"
+      value {
+        [type.googleapis.com/tfx.orchestration.executable_spec.BeamExecutableSpec] {
+          python_executor_spec {
+            class_path: "tfx.components.statistics_gen.executor.Executor"
+          }
+        }
+      }
+    }
+    executor_specs {
+      key: "Trainer"
+      value {
+        [type.googleapis.com/tfx.orchestration.executable_spec.PythonClassExecutableSpec] {
+          class_path: "tfx.components.trainer.executor.GenericExecutor"
+        }
+      }
+    }
+    custom_driver_specs {
+      key: "CsvExampleGen"
+      value {
+        [type.googleapis.com/tfx.orchestration.executable_spec.PythonClassExecutableSpec] {
+          class_path: "tfx.components.example_gen.driver.FileBasedDriver"
+        }
+      }
+    }
+  }
+}

--- a/tfx/dsl/components/base/base_component.py
+++ b/tfx/dsl/components/base/base_component.py
@@ -94,11 +94,13 @@ class BaseComponent(base_node.BaseNode, abc.ABC):
                        f'not copyable.') from e
 
     driver_class = self.__class__.DRIVER_CLASS
+    # Set self.spec before super.__init__() where node registration happens.
+    # This enable node input checking on node context registration.
+    self.spec = spec
     super().__init__(
         executor_spec=executor_spec_obj,
         driver_class=driver_class,
     )
-    self.spec = spec
     self._validate_component_class()
     self._validate_spec(spec)
     self.platform_config = None

--- a/tfx/dsl/components/common/resolver.py
+++ b/tfx/dsl/components/common/resolver.py
@@ -257,11 +257,10 @@ class Resolver(base_node.BaseNode):
           types.Channel(type=c.type).set_artifacts([c.type()]))
     super().__init__(driver_class=_ResolverDriver)
 
+  @property
   @doc_controls.do_not_generate_docs
-  def trace(
-      self, input_node: resolver_op.OpNode) -> resolver_op.OpNode:
-    """Get ResolverFunction's output OpNode."""
-    return self._resolver_function.trace(input_node)
+  def resolver_function(self) -> resolver_function.ResolverFunction:
+    return self._resolver_function
 
   @property
   @doc_controls.do_not_generate_docs

--- a/tfx/dsl/input_resolution/ops/skip_if_empty_op.py
+++ b/tfx/dsl/input_resolution/ops/skip_if_empty_op.py
@@ -1,0 +1,36 @@
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module for SkipIfEmpty operator."""
+
+from typing import Sequence
+
+from tfx.dsl.input_resolution import resolver_op
+from tfx.orchestration.portable.input_resolution import exceptions
+from tfx.utils import typing_utils
+
+
+class SkipIfEmpty(
+    resolver_op.ResolverOp,
+    arg_data_types=(resolver_op.DataTypes.ARTIFACT_MULTIMAP_LIST,),
+    return_data_type=resolver_op.DataTypes.ARTIFACT_MULTIMAP_LIST,
+):
+  """SkipIfEmpty operator."""
+
+  def apply(
+      self,
+      input_dict_list: Sequence[typing_utils.ArtifactMultiMap],
+  ) -> Sequence[typing_utils.ArtifactMultiMap]:
+    if not input_dict_list:
+      raise exceptions.SkipSignal()
+    return input_dict_list

--- a/tfx/dsl/input_resolution/ops/skip_if_empty_op_test.py
+++ b/tfx/dsl/input_resolution/ops/skip_if_empty_op_test.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for tfx.dsl.input_resolution.ops.skip_if_empty_op."""
+
+import tensorflow as tf
+
+from tfx.dsl.input_resolution.ops import skip_if_empty_op
+from tfx.dsl.input_resolution.ops import test_utils
+from tfx.orchestration.portable.input_resolution import exceptions
+
+SkipIfEmpty = skip_if_empty_op.SkipIfEmpty
+
+
+class SkipIfEmptyOpTest(tf.test.TestCase):
+
+  def create_artifacts(self, uri_prefix: str, n: int):
+    return [
+        test_utils.DummyArtifact(uri=uri_prefix + str(i))
+        for i in range(1, n + 1)
+    ]
+
+  def testSkipIfEmpty_OnEmpty_RaisesSkipSignal(self):
+    with self.assertRaises(exceptions.SkipSignal):
+      test_utils.run_resolver_op(SkipIfEmpty, [])
+
+  def testSkipIfEmpty_OnNonEmpty_ReturnsAsIs(self):
+    x1, x2, x3 = self.create_artifacts(uri_prefix='x/', n=3)
+    input_dicts = [{'x': [x1]}, {'x': [x2]}, {'x': [x3]}]
+
+    result = test_utils.run_resolver_op(SkipIfEmpty, input_dicts)
+    self.assertEqual(result, [{'x': [x1]}, {'x': [x2]}, {'x': [x3]}])
+
+
+if __name__ == '__main__':
+  tf.test.main()

--- a/tfx/dsl/input_resolution/resolver_op.py
+++ b/tfx/dsl/input_resolution/resolver_op.py
@@ -252,6 +252,9 @@ class ResolverOp(metaclass=_ResolverOpMeta):
   actually create the FooOp instance, use FooOp.create().
   """
 
+  def __init__(self, *unused_args, **unused_kwargs):
+    """Dummy constructor to bypass false negative pytype alarm."""
+
   @abc.abstractmethod
   def apply(
       self,


### PR DESCRIPTION
Recreated from original PR: https://github.com/tensorflow/tfx/pull/4423

Naive ForEach compiler implementation using Unnest operator.

Long term direction: since interaction between Cond and ForEach is too complex to be encoded as ResolverSteps, we should encode context information directly (without using ResolverSteps) and let the input resolution stack (e.g. inputs_utils.py) determines the correct inputs based on the context information (e.g. nested Cond and ForEach).
